### PR TITLE
Added tests for touch events

### DIFF
--- a/tests/long-press-spec.js
+++ b/tests/long-press-spec.js
@@ -10,7 +10,7 @@ var window = null;
 // intercept request for schema
 nock.disableNetConnect();
 
-describe('long-press', function () {
+describe('long-press-mouse', function () {
 
     // create a new browser instance before each test
     beforeEach(function (done) {
@@ -90,3 +90,86 @@ describe('long-press', function () {
     });
 
 });
+
+describe('long-press-touch', function () {
+
+    // create a new browser instance before each test
+    beforeEach(function (done) {
+
+        nock('http://localhost:8080')
+            .get('/src/long-press-event.js')
+            .replyWithFile(200, path.resolve('./src/long-press-event.js'));
+
+        var virtualConsole = new jsdom.VirtualConsole();
+
+        var options = {
+            url: 'http://localhost:8080',
+            contentType: 'text/html',
+            runScripts: 'dangerously',
+            resources: 'usable',
+            virtualConsole: virtualConsole.sendTo(console) // redirect browser output to terminal
+        };
+
+        // load test page from disk (includes links to dependent scripts)
+        jsdom.JSDOM.fromFile(path.resolve(__dirname, 'test-page.html'), options).then(function(dom) {
+
+            // expose the window/document object to tests
+            window = dom.window;
+            window.ontouchstart = function() {};
+            document = window.document;
+
+            // slight wait to allow scripts to load
+            setTimeout(function() {
+                expect(document).toBeDefined();
+                expect(document.title).toBe('long-press Test Page');
+                done();
+            }, 250);
+        });
+    });
+
+
+    it('should fire long-press event after default 1.5s', function(done) {
+
+        var el = document.createElement('div');
+
+        document.body.appendChild(el);
+
+        el.addEventListener('long-press', function(e) {
+            expect(e).toBeDefined();
+            expect(e.target).toEqual(el);
+            done();
+        });
+
+        window.fireEvent(el, 'touchstart');
+
+        setTimeout(function() {
+            window.fireEvent(el, 'touchend');
+        }, 1500);
+    });
+
+
+    it('should fire long-press event using data-long-press-delay', function(done) {
+
+        var longPressDealy = 100;
+
+        var el = document.createElement('div');
+
+        el.setAttribute('data-long-press-delay', longPressDealy);
+
+        document.body.appendChild(el);
+
+        el.addEventListener('long-press', function(e) {
+            expect(e).toBeDefined();
+            expect(e.target).toEqual(el);
+            done();
+        });
+
+        window.fireEvent(el, 'touchstart');
+
+        setTimeout(function() {
+            window.fireEvent(el, 'touchend');
+        }, longPressDealy + 10);
+    });
+
+});
+

--- a/tests/test-page.html
+++ b/tests/test-page.html
@@ -18,10 +18,8 @@
                         e.ctrlKey = false;
                         e.shiftKey = false;
                         e.metaKey = false;
-                        e.initUIEvent('touchend', true, true);
-
+                        e.initUIEvent(eventName, true, true, window, 0);
                         el.dispatchEvent(e);
-                        console.log('touch event fired');
                     }
                     else {
                         e = document.createEvent('HTMLEvents');


### PR DESCRIPTION
I'm emulating a touch browser by adding
```
window.ontouchstart = function() {};
```
to the window object, such that the code will listen on touch events instead of mouse events.