### PR TITLE
Update package.json `main` property for cleaner imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "long-press-event",
   "version": "2.4.2",
   "description": "A 1k script that adds a long-press event to the DOM using pure JS",
-  "main": "dev-server.js",
+  "main": "src/long-press-event.js",
   "scripts": {
     "start": "node server/dev-server.js",
     "test": "jasmine-node tests --verbose --color --forceexit --junitreport || true",


### PR DESCRIPTION
This updates the `main` property in package.json to point to "src/long-press-event.js" instead of "dev-server.js". This way the module can be imported into other projects as `import 'long-press-event'` instead of needing to import the entire path such as `import 'long-press-event/src/long-press-event.js'` or `import 'long-press-event/dist/long-press-event.min.js'`.

This is following the same pattern used in the `swiped-events` project: https://github.com/john-doherty/swiped-events/blob/master/package.json#L5